### PR TITLE
docs: Modify upgrade 0.1.x to 0.2 to increase CREATE SCHEMA

### DIFF
--- a/src/admin/upgrading.md
+++ b/src/admin/upgrading.md
@@ -54,6 +54,7 @@ Let's assume your `pgvecto.rs` version is `0.1.x` (replace `x` with a number).
 ```sql
 UPDATE pg_catalog.pg_extension SET extversion = '0.1.x' where extname = 'vectors';
 UPDATE pg_catalog.pg_extension SET extrelocatable = true where extname = 'vectors';
+CREATE SCHEMA vectors;
 ALTER EXTENSION vectors SET SCHEMA vectors;
 UPDATE pg_catalog.pg_extension SET extrelocatable = false where extname = 'vectors';
 ALTER EXTENSION vectors UPDATE TO '0.2.0';


### PR DESCRIPTION
When executing the migration, it fails because the vectors schema does not exist.  Adding CREATE SCHEMA vectors; before doing the switch resolved the problem. 

Tested on PG16, going from 0.1.13 -> 0.2