### PR TITLE
feat: add function alter_vector_index

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -128,6 +128,7 @@ export default defineConfig({
           text: 'FAQs',
           collapsed: false,
           items: [
+            { text: 'General FAQ', link: '/faqs/general' },
             { text: 'pgvecto.rs vs. pgvector', link: '/faqs/comparison-pgvector' },
             { text: 'pgvecto.rs vs. specialized vectordb', link: '/faqs/comparison-with-specialized-vectordb' },
             { text: `Benchmarks`, link: '/faqs/benchmark' },

--- a/src/admin/configuration.md
+++ b/src/admin/configuration.md
@@ -12,3 +12,25 @@ psql -U postgres -c 'ALTER SYSTEM SET logging_collector = on;'
 sudo systemctl restart postgresql.service   # for pgvecto.rs running with systemd
 docker restart pgvecto-rs-demo  # for pgvecto.rs running in docker
 ```
+
+## Index configuration <Badge type="tip" text="since v0.3.0" />
+
+For each index, there are a number of configuration items that are variable. Unlike options, they support real-time modification after the index has been created. These items can be configured by function `alter_vector_index`.
+
+```sql
+-- alter_vector_index(dim: OID, key: TEXT, value: TEXT)
+SELECT alter_vector_index('index_name'::regclass::oid, 'configuration_name', 'value');
+```
+
+Here are all the available configurations.
+
+### Threads for backend optimizing
+
+By default, each vector index is optimized by only one thread at the backend. However, if you have multiple idle CPUs and want to take advantage of them, you can increase the number of threads.
+
+Set the `key` argument to `optimizing.threads` and the `value` argument to the desired number of threads.
+
+```sql
+-- alter_vector_index(dim: OID, key = 'optimizing.threads', value: TEXT as INT[1-65535])
+SELECT alter_vector_index('table_col_idx'::regclass::oid, 'optimizing.threads', '4');
+```

--- a/src/admin/upgrading.md
+++ b/src/admin/upgrading.md
@@ -2,10 +2,12 @@
 
 ## General Steps
 
-If you update the extension to a new version, let's say it's `999.999.999`. This command helps you to update the schema of extension:
+If you update the extension to a new version, let's say it's `a.b.c`. This command helps you to update the schema of extension:
 
 ```sql
-ALTER EXTENSION vectors UPDATE TO '999.999.999';
+ALTER EXTENSION vectors UPDATE;
+-- or
+ALTER EXTENSION vectors UPDATE TO 'a.b.c';
 ```
 
 If you're upgrading from `0.1.x`, please read [Upgrading from 0.1.x](#upgrade-from-01x).
@@ -47,16 +49,19 @@ REINDEX INDEX t_val_idx_2;
 
 ## Upgrade from 0.1.x
 
-You need to follow these steps to make `ALTER EXTENSION vectors UPDATE TO '0.2.0'` work.
+You need to follow these steps to make `ALTER EXTENSION vectors UPDATE` work.
 
 Let's assume your `pgvecto.rs` version is `0.1.x` (replace `x` with a number).
 
 ```sql
+CREATE SCHEMA IF NOT EXISTS vectors;
 UPDATE pg_catalog.pg_extension SET extversion = '0.1.x' where extname = 'vectors';
 UPDATE pg_catalog.pg_extension SET extrelocatable = true where extname = 'vectors';
 ALTER EXTENSION vectors SET SCHEMA vectors;
 UPDATE pg_catalog.pg_extension SET extrelocatable = false where extname = 'vectors';
-ALTER EXTENSION vectors UPDATE TO '0.2.0';
+ALTER EXTENSION vectors UPDATE;
 ```
 
+::: tip
 `pgvecto.rs` is installed in schema `vectors` from `0.2.0`, you may need to set `search_path` for the database.
+:::

--- a/src/faqs/general.md
+++ b/src/faqs/general.md
@@ -1,0 +1,51 @@
+# General FAQ
+
+## The vector type or operator class is not found
+
+In most cases, this is due to a missing schema search path or a lack of permissions. 
+
+Please go through this checklist:
+
+1. Run `\dx` with `psql` or `SELECT * FROM pg_extension;` and check if the extension exists.
+
+```bash
+postgres=# \dx
+                                                    List of installed extensions
+  Name   |    Version    |   Schema   |                                         Description                                          
+---------+---------------+------------+----------------------------------------------------------------------------------------------
+ vectors | 0.3.0         | vectors    | vectors: Vector database plugin for Postgres, written in Rust, specifically designed for LLM
+```
+
+If not, install it with `CREATE EXTENSION vectors;`
+
+2. Run `SHOW search_path;` and check if it contains `vectors`.
+
+```bash
+postgres=# SHOW search_path;
+       search_path        
+--------------------------
+ "$user", public, vectors
+```
+If not, set it with `SET search_path="$user", public, vectors;`
+
+3. If `pgvecto.rs` is installed by another superuser
+
+Run `\dn` with `psql` or `SELECT nspname FROM pg_catalog.pg_namespace;` and check if the schema `vectors` exists.
+
+```bash
+postgres=# SELECT current_user;
+ current_user 
+--------------
+ tensorchord
+
+postgres=# \dn
+       List of schemas
+  Name   |       Owner       
+---------+-------------------
+ public  | pg_database_owner
+ vectors | postgres
+```
+
+If not, log in as the superuser and grant schema permissions to `current_user`:
+
+`GRANT ALL ON SCHEMA vectors to tensorchord;`


### PR DESCRIPTION
Close #70 

1. Add document for new function `alter_vector_index`
2. Rename `999.999.999` to `a.b.c` for upgrading
3. Add new docs of `General FAQ` about vector not found

Related issues:
https://github.com/tensorchord/pgvecto.rs/issues/441
https://github.com/tensorchord/pgvecto.rs/issues/449
https://github.com/tensorchord/pgvecto.rs/issues/383
https://github.com/tensorchord/pgvecto.rs/issues/385