### PR TITLE
Update adopters.md with postgresql_embedded

### DIFF
--- a/src/community/adopters.md
+++ b/src/community/adopters.md
@@ -3,6 +3,7 @@
 ## immich
 
 [immich](https://github.com/immich-app/immich) is a self-hosted photo and video backup solution directly from your mobile phone. it is [using pgvecto.rs to search](https://immich.app/docs/features/search).
+[postgresql_embedded](https://github.com/theseus-rs/postgresql-embedded) is a set of utilities for installing, running and managing PostgreSQL and extensions in Rust with support for [installing pgvecto.rs](https://github.com/theseus-rs/postgresql-embedded/tree/main/postgresql_extensions#repositories).
 
 ![](https://immich.app/assets/images/search-ex-2-707fe5ab1ab89621a7a1f3e8807b724a.webp)
 


### PR DESCRIPTION
Support for pgvecto.rs was [requested by several users](https://github.com/theseus-rs/postgresql-embedded/issues/47) of [postgresql_embedded](https://github.com/theseus-rs/postgresql-embedded); adding an adopter link for other users that may be interested.